### PR TITLE
Rename manifest_path arg to spellbook_path

### DIFF
--- a/spellbook_ingredients/dump_spellbook_resources_to_csv.py
+++ b/spellbook_ingredients/dump_spellbook_resources_to_csv.py
@@ -2,13 +2,15 @@ import os
 import csv
 import json
 
+
 def dump_spellbook_resources_to_csv(manifest_path, csv_path):
     manifest_file = f'{manifest_path}target/manifest.json'
     if os.path.exists(manifest_file):
         with open(manifest_file) as f:
             manifest = json.load(f)
     else:
-        raise Exception("Manifest file not found! Make sure you ran `dbt compile` first.")
+        raise Exception(
+            "Manifest file not found! Make sure you ran `dbt compile` in the Spellbook repo first.")
         exit(1)
 
     # Extract the names of all the tables that are resources to Spells
@@ -27,4 +29,4 @@ def dump_spellbook_resources_to_csv(manifest_path, csv_path):
         writer = csv.writer(file)
         _ = writer.writerow(fieldnames)
         for name in resource_names:
-           _ = writer.writerow([name])
+            _ = writer.writerow([name])

--- a/spellbook_ingredients/main.py
+++ b/spellbook_ingredients/main.py
@@ -4,16 +4,19 @@ import sys
 from write_to_dune import write_to_dune
 from dump_spellbook_resources_to_csv import dump_spellbook_resources_to_csv
 
-def main(api_key, manifest_path, csv_path):
-    dump_spellbook_resources_to_csv(manifest_path, csv_file_path)
+
+def main(api_key, spellbook_path, csv_path):
+    dump_spellbook_resources_to_csv(spellbook_path, csv_file_path)
     write_to_dune(api_key, csv_file_path)
+
 
 if __name__ == "__main__":
     if len(sys.argv) < 3 or len(sys.argv) > 4:
-        raise('Usage: python main.py API_KEY MANIFEST_PATH [CSV_FILE_PATH]')
+        raise ('Usage: python main.py API_KEY MANIFEST_PATH [CSV_FILE_PATH]')
         exit(1)
 
     api_key = sys.argv[1]
-    manifest_path = sys.argv[2]
-    csv_file_path = sys.argv[3] if len(sys.argv) == 4 else os.path.join(os.getcwd(), "spellbook_resource_name_dump.csv")
-    main(api_key, manifest_path, csv_file_path)
+    spellbook_path = sys.argv[2]
+    csv_file_path = sys.argv[3] if len(sys.argv) == 4 else os.path.join(
+        os.getcwd(), "spellbook_resource_name_dump.csv")
+    main(api_key, spellbook_path, csv_file_path)


### PR DESCRIPTION
Renamed `manifest_path` argument to `spellbook_path` as I've hardcoded the path to the manifest inside the main Spellbook dir.